### PR TITLE
Fix MCP stdio env vars and external coding-agent model picks

### DIFF
--- a/ducky_app/frontend/mcp_block.py
+++ b/ducky_app/frontend/mcp_block.py
@@ -2,12 +2,41 @@
 
 from __future__ import annotations
 
+import os
 import re
 import sys
 from pathlib import Path
 
 from frontend.bundle_root import is_packaged_runtime
 from frontend.settings import PanelSettings
+
+# Windows MCP clients that declare an explicit ``env`` block for a stdio server
+# typically REPLACE the child process's environment instead of merging it with
+# the parent's. A frozen PyInstaller exe cannot boot without these — no
+# SystemRoot/TEMP means the Python runtime/DLL loader fails before it can even
+# open its stdio pipes, so the client just sees an instant CONNECTION_CLOSED.
+_REQUIRED_ENV_KEYS = (
+    "SystemRoot",
+    "windir",
+    "TEMP",
+    "TMP",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "USERPROFILE",
+    "ComSpec",
+    "PATHEXT",
+    "PATH",
+)
+
+
+def _base_os_env() -> dict[str, str]:
+    """Essential Windows env vars, read from this (healthy) process's own env."""
+    out: dict[str, str] = {}
+    for key in _REQUIRED_ENV_KEYS:
+        val = os.environ.get(key, "")
+        if val:
+            out[key] = val
+    return out
 
 VERSIONED_EXE_RE = re.compile(
     r"^UEFN-Ducky-(\d+)\.(\d+)\.(\d+)\.exe$",
@@ -72,9 +101,8 @@ def resolve_bridge_args(settings: PanelSettings) -> list[str]:
 
 def build_uefn_server_block(settings: PanelSettings) -> dict:
     """Return dict suitable for mcpServers['uefn'] (stdio)."""
-    env = {
-        "UEFN_DUCKY_PORT": str(settings.port),
-    }
+    env = _base_os_env()
+    env["UEFN_DUCKY_PORT"] = str(settings.port)
     return {
         "type": "stdio",
         "command": resolve_bridge_command(),

--- a/ducky_app/frontend/ui_web/web/src/components/ChatPane.tsx
+++ b/ducky_app/frontend/ui_web/web/src/components/ChatPane.tsx
@@ -3,6 +3,7 @@ import { Icons } from "../icons/Icons";
 import { ScopedCss, useScopedClass } from "../utils/scopedCss";
 import { ModeSelector } from "./ModeSelector";
 import { ModelSelector } from "./ModelSelector";
+import { EffortSelector } from "./EffortSelector";
 import { modelShowsThinkingEffort } from "./ducky/duckyProfileForm";
 import { usePluginContributions } from "../hooks/usePluginContributions";
 import { ComposerAttachmentChips } from "./ComposerAttachmentChips";
@@ -728,16 +729,33 @@ export function ChatPane({
   const noModelsAvailable = codingAgent === "ducky" && catalogReady && modelsCount === 0;
   const externalAgent = codingAgent !== "ducky";
 
+  // True when every invited member runs an external coding agent (Claude Code,
+  // Codex, …) or delegates to a nested group — none of them need an Anthropic/
+  // OpenAI API key, so the group must not be gated on hasApiKey/noModelsAvailable.
+  const groupUsesExternalOnly =
+    !!chat.isGroup &&
+    groupMembers.length > 0 &&
+    groupMembers.every((m) => {
+      if (m.is_group) return true;
+      const agent = (m.coding_agent || "").trim().toLowerCase();
+      return !!agent && agent !== "ducky";
+    });
+
   const hasText = !!inputText.trim();
   // Group chats ignore attachments — members only get the text prompt.
   const hasContent = hasText || (!chat.isGroup && attachments.length > 0);
   const visionBlocked = hasImages && !modelSupportsVision && !externalAgent;
   const canCompose =
     (chat.isGroup
-      ? groupMembers.length > 0 && hasApiKey && !noModelsAvailable
+      ? groupMembers.length > 0 && (groupUsesExternalOnly || (hasApiKey && !noModelsAvailable))
       : externalAgent || (!noModelsAvailable && hasApiKey && !!selectedModel)) &&
     hasContent &&
     !visionBlocked;
+  // UI-facing "no models" state — suppressed for groups whose every member
+  // already runs an external coding agent (Claude Code, …), which needs no
+  // API key. Distinct from noModelsAvailable, which single-chat canCompose
+  // still uses as-is.
+  const modelsUnavailable = noModelsAvailable && !(chat.isGroup && groupUsesExternalOnly);
   const canSend = canCompose && !agentRunning;
   const canQueue = canCompose && agentRunning;
   const isEmpty = messages.length === 0 && !streamBuffer && !agentRunning;
@@ -753,7 +771,7 @@ export function ChatPane({
 
   const paneFlex = flexGrow != null ? `${flexGrow} 1 0%` : "1 1 0%";
 
-  const sendBtnTitle = noModelsAvailable
+  const sendBtnTitle = modelsUnavailable
     ? "Open Settings → LLMs to add an API key and configure models"
     : canQueue
       ? "Queue follow-up (runs when this turn finishes)"
@@ -763,7 +781,7 @@ export function ChatPane({
           : "Send"
         : "Add API key, model, and message or attachments";
 
-  const sendBtnClass = noModelsAvailable
+  const sendBtnClass = modelsUnavailable
     ? "chat-pane-send-btn chat-pane-send-btn--settings-cta"
     : hasContent
       ? canSend || canQueue
@@ -1139,9 +1157,9 @@ export function ChatPane({
           </div>
 
           <div className="chat-pane-composer-pane chat-pane-composer-pane--type">
-            {(noModelsAvailable || visionBlocked || attachmentError) && (
+            {(modelsUnavailable || visionBlocked || attachmentError) && (
               <div className={`composer-attach-warning${visionBlocked ? " is-vision-blocked" : ""}`}>
-                {noModelsAvailable
+                {modelsUnavailable
                   ? "No models available — open Settings → LLMs to add an API key and configure a provider."
                   : visionBlocked
                     ? `${displayModelLabel} cannot use images — switch to a vision model or remove images.`
@@ -1214,14 +1232,7 @@ export function ChatPane({
           <div className="chat-pane-input-toolbar">
             <div className="chat-pane-input-toolbar-left">
               {!chat.isGroup ? (
-                <ModeSelector
-                  activeMode={agentMode}
-                  setMode={setAgentMode}
-                  showEffort={showThinkingEffort}
-                  convId={chat.id}
-                  effort={thinkingEffort}
-                  onEffortChange={setThinkingEffort}
-                />
+                <ModeSelector activeMode={agentMode} setMode={setAgentMode} />
               ) : null}
               <ContextMeter
                 usedTokens={contextUsage.used_tokens}
@@ -1254,13 +1265,21 @@ export function ChatPane({
                     preserveSelection
                     onModelMetaChange={handleModelMetaChange}
                   />
+                  {showThinkingEffort ? (
+                    <EffortSelector
+                      convId={chat.id}
+                      provider={chat.provider || codingAgent || "anthropic"}
+                      value={thinkingEffort}
+                      onChange={setThinkingEffort}
+                    />
+                  ) : null}
                 </>
               ) : null}
             </div>
 
             <div className="chat-pane-input-toolbar-right">
               <SnipButton
-                disabled={noModelsAvailable}
+                disabled={modelsUnavailable}
                 onCaptured={(file, meta) =>
                   void addFiles([file], {
                     imagesOnly: true,
@@ -1271,7 +1290,7 @@ export function ChatPane({
               <VoiceControls
                 chatId={chat.id}
                 disabled={
-                  noModelsAvailable ||
+                  modelsUnavailable ||
                   (Boolean(chat.isGroup) && groupMembers.length === 0)
                 }
                 inputText={inputText}
@@ -1305,11 +1324,11 @@ export function ChatPane({
                 <button
                   type="button"
                   onClick={() => handleSend()}
-                  disabled={!noModelsAvailable && !canSend}
+                  disabled={!modelsUnavailable && !canSend}
                   title={sendBtnTitle}
                   className={sendBtnClass}
                 >
-                  {noModelsAvailable ? <Icons.Settings /> : <Icons.Send />}
+                  {modelsUnavailable ? <Icons.Settings /> : <Icons.Send />}
                 </button>
               )}
             </div>

--- a/ducky_app/frontend/ui_web/web/src/components/ducky/DuckyModelPicker.tsx
+++ b/ducky_app/frontend/ui_web/web/src/components/ducky/DuckyModelPicker.tsx
@@ -1,10 +1,6 @@
 import { useMemo, useRef, type ReactNode } from "react";
 
-import {
-  isCodingAgentFavoriteId,
-  parseFavoriteSelection,
-  qualifyFavorite,
-} from "../../hooks/favoriteModelsCatalog";
+import { parseFavoriteSelection, qualifyFavorite } from "../../hooks/favoriteModelsCatalog";
 import { getCachedModels } from "../../hooks/modelsCatalogCache";
 import { codingAgentFromModel } from "./duckyProfileForm";
 import { ModelSelector } from "../ModelSelector";
@@ -39,7 +35,12 @@ function normalizeAgentModelId(_agentId: string, modelId: string): string {
 export function qualifyModelPick(agent: string, modelId: string): string {
   const mid = normalizeAgentModelId(agent, (modelId || "").trim());
   if (!mid) return "";
-  if (isCodingAgentFavoriteId(agent)) return qualifyFavorite(agent, mid);
+  // The caller (ModelSelector.pickModel) only ever passes "ducky" or a real,
+  // live coding-agent id here — isCodingAgentFavoriteId(agent) with no live
+  // agents list always defaults to [] and never matches, silently dropping
+  // every coding-agent pick (Claude Code, Codex, Cursor…) back to "".
+  const normAgent = agent.trim().toLowerCase().replace(/-/g, "_");
+  if (normAgent && normAgent !== "ducky") return qualifyFavorite(normAgent, mid);
   const bare = mid.includes(":") ? mid.slice(mid.indexOf(":") + 1) : mid;
   const row = (getCachedModels() ?? []).find((r) => r.id === bare || r.id === mid);
   const backend = (row?.providerKey || "").trim().toLowerCase().replace(/-/g, "_");


### PR DESCRIPTION
## Summary
- Whitelist required Windows env vars (SystemRoot, TEMP, PATH, ...) in the `uefn` MCP stdio server block — some IDE clients replace rather than merge the declared env, and a frozen PyInstaller exe can't boot without them (instant CONNECTION_CLOSED).
- Fix `qualifyModelPick()`: it called `isCodingAgentFavoriteId(agent)`, which always resolves against an empty live-agents list and never matches — every coding-agent model pick (Claude Code, Codex, Cursor…) was silently collapsing to `""`.
- Stop gating group chats on `hasApiKey`/`noModelsAvailable` when every invited member already runs an external coding agent (none of them need an Anthropic/OpenAI key).
- Move the thinking-effort control into its own `EffortSelector` next to the model picker.

## Test plan
- [x] `tsc -b` — clean type-check
- [x] `vitest run` — full suite passes the same as on `main`, plus fixes `qualifyModelPick > qualifies coding-agent picks` (was failing on `main`)
- [x] Manual sanity import of `mcp_block.py` — `_base_os_env()` returns the expected keys

