### PR TITLE
Slash command menu in the composer

### DIFF
--- a/ducky_app/frontend/ui_web/web/src/components/ChatPane.tsx
+++ b/ducky_app/frontend/ui_web/web/src/components/ChatPane.tsx
@@ -75,6 +75,16 @@ import { isEnglishLang } from "../views/settings/translationLanguages";
 import { VoiceControls, type LiveVoiceUiHandlers } from "../voice/VoiceControls";
 import { VoiceOverlay } from "../voice/VoiceOverlay";
 import { SnipButton } from "./SnipButton";
+import { captureSnipFile } from "./snipCapture";
+import { SlashCommandMenu } from "./SlashCommandMenu";
+import {
+  commandsForScope,
+  composerPlaceholder,
+  filterCommands,
+  matchSlashCommand,
+  readSlashQuery,
+  type SlashCommand,
+} from "./slashCommands";
 import { GroupMemberStrip } from "./GroupMemberStrip";
 import type { GroupMemberDto } from "../types/panel";
 import {
@@ -193,6 +203,10 @@ export function ChatPane({
     initialComposer?.selectedModelDisplayName ?? chat.model ?? "",
   );
   const [isDragOver, setIsDragOver] = useState(false);
+  const [slashActiveIndex, setSlashActiveIndex] = useState(0);
+  const [slashDismissed, setSlashDismissed] = useState(false);
+  const [slashStatus, setSlashStatus] = useState("");
+  const [modelPickerSignal, setModelPickerSignal] = useState(0);
   const [chatPlan, setChatPlan] = useState<ChatPlan | null>(null);
   const [chatPlanProgress, setChatPlanProgress] = useState<PlanProgress | null>(null);
   const planAllDone = useMemo(() => {
@@ -823,12 +837,87 @@ export function ChatPane({
     ],
   );
 
+  const availableCommands = useMemo(
+    () => commandsForScope({ codingAgent, isGroup: Boolean(chat.isGroup) }),
+    [codingAgent, chat.isGroup],
+  );
+  const slashQuery = readSlashQuery(inputText);
+  const slashMatches = useMemo(
+    () => (slashQuery === null ? [] : filterCommands(availableCommands, slashQuery)),
+    [availableCommands, slashQuery],
+  );
+  const slashMenuOpen = !slashDismissed && slashMatches.length > 0;
+
+  useEffect(() => {
+    setSlashActiveIndex(0);
+    if (slashQuery === null) setSlashDismissed(false);
+  }, [slashQuery]);
+
+  useEffect(() => {
+    if (!slashStatus) return;
+    const t = window.setTimeout(() => setSlashStatus(""), 5000);
+    return () => window.clearTimeout(t);
+  }, [slashStatus]);
+
+  const runSlashCommand = useCallback(
+    (command: SlashCommand, argument: string) => {
+      void command.run({
+        chatId: chat.id,
+        argument,
+        setAgentMode,
+        openModelPicker: () => setModelPickerSignal((n) => n + 1),
+        captureSnip: () => {
+          void (async () => {
+            const snip = await captureSnipFile();
+            if (!snip) {
+              setSlashStatus("Snip cancelled — nothing captured.");
+              return;
+            }
+            await addFiles([snip.file], { imagesOnly: true, projectPath: snip.projectPath });
+          })();
+        },
+        // Re-opening the bare prefix lists everything this chat supports.
+        showHelp: () => setInputText("/"),
+        report: setSlashStatus,
+      });
+    },
+    [chat.id, addFiles],
+  );
+
+  /** Menu pick: commands taking an argument only get completed, not run. */
+  const completeSlashCommand = useCallback(
+    (command: SlashCommand) => {
+      if (command.requiresArgument) {
+        setInputText(`/${command.name} `);
+        textareaRef.current?.focus();
+        return;
+      }
+      setInputText("");
+      runSlashCommand(command, "");
+    },
+    [runSlashCommand],
+  );
+
   const handleSend = (overrideText?: string) => {
+    const text = (overrideText ?? inputText).trim();
+
+    // A recognised command acts on the panel — it never reaches the ducky, so
+    // it runs before the "no models" gate (that is when /model matters most).
+    const slash = overrideText ? null : matchSlashCommand(text, availableCommands);
+    if (slash) {
+      if (slash.command.requiresArgument && !slash.argument) {
+        setSlashStatus(`/${slash.command.name} needs ${slash.command.args ?? "an argument"}.`);
+        return;
+      }
+      setInputText("");
+      runSlashCommand(slash.command, slash.argument);
+      return;
+    }
+
     if (!chat.isGroup && noModelsAvailable) {
       requestOpenSettings("LLMs");
       return;
     }
-    const text = (overrideText ?? inputText).trim();
     const apiAttachments = overrideText ? [] : toApiAttachments();
     if (!text && apiAttachments.length === 0) return;
 
@@ -1125,6 +1214,15 @@ export function ChatPane({
             />
           </div>
         ) : null}
+        <div className="chat-pane-composer-host">
+          {slashMenuOpen ? (
+            <SlashCommandMenu
+              commands={slashMatches}
+              activeIndex={slashActiveIndex}
+              onHover={setSlashActiveIndex}
+              onSelect={completeSlashCommand}
+            />
+          ) : null}
         <div
           ref={inputBoxRef}
           className={`no-drag chat-pane-input-box${isFocused ? " chat-pane-input-box--focused" : ""}${isDragOver ? " chat-pane-input-box--drag-over" : ""}${liveVoice ? " chat-pane-input-box--voice" : ""}`}
@@ -1166,6 +1264,7 @@ export function ChatPane({
                     : attachmentError}
               </div>
             )}
+            {slashStatus ? <div className="slash-command-status">{slashStatus}</div> : null}
             <ComposerAttachmentChips
               attachments={attachments}
               onRemove={removeAttachment}
@@ -1193,26 +1292,43 @@ export function ChatPane({
               onBlur={() => setIsFocused(false)}
               onKeyDown={(e) => {
                 if (!chat.isGroup && noModelsAvailable) return;
+                if (slashMenuOpen) {
+                  const count = slashMatches.length;
+                  if (e.key === "ArrowDown") {
+                    e.preventDefault();
+                    setSlashActiveIndex((i) => (i + 1) % count);
+                    return;
+                  }
+                  if (e.key === "ArrowUp") {
+                    e.preventDefault();
+                    setSlashActiveIndex((i) => (i - 1 + count) % count);
+                    return;
+                  }
+                  if (e.key === "Escape") {
+                    e.preventDefault();
+                    setSlashDismissed(true);
+                    return;
+                  }
+                  const picked = slashMatches[slashActiveIndex];
+                  if (picked && (e.key === "Tab" || (e.key === "Enter" && !e.shiftKey))) {
+                    e.preventDefault();
+                    completeSlashCommand(picked);
+                    return;
+                  }
+                }
                 if (e.key === "Enter" && !e.shiftKey) {
                   e.preventDefault();
                   handleSend();
                 }
               }}
-              placeholder={
-                liveVoice && liveVoiceHandlers?.muted
-                  ? "You're muted — type to chat (Shift+Enter for newline)"
-                  : chat.isGroup
-                    ? groupMembers.length === 0
-                      ? "Invite a ducky above to start the roundtable…"
-                      : agentRunning
-                        ? "Add a follow-up… (Shift+Enter for newline)"
-                        : "Message the group… (Shift+Enter for newline)"
-                    : noModelsAvailable
-                      ? "No models available — use the button below to open Settings → LLMs"
-                      : agentRunning
-                        ? "Add a follow-up… (Shift+Enter for newline)"
-                        : `Ask ${displayModelLabel}... (Shift+Enter for newline)`
-              }
+              placeholder={composerPlaceholder({
+                liveVoiceMuted: Boolean(liveVoice && liveVoiceHandlers?.muted),
+                isGroup: Boolean(chat.isGroup),
+                groupEmpty: groupMembers.length === 0,
+                agentRunning,
+                noModelsAvailable,
+                modelLabel: displayModelLabel,
+              })}
               className="chat-pane-textarea"
               disabled={!chat.isGroup && noModelsAvailable}
               style={
@@ -1263,6 +1379,7 @@ export function ChatPane({
                     setCodingAgent={setCodingAgent}
                     convId={chat.id}
                     preserveSelection
+                    openSignal={modelPickerSignal}
                     onModelMetaChange={handleModelMetaChange}
                   />
                   {showThinkingEffort ? (
@@ -1333,6 +1450,7 @@ export function ChatPane({
               )}
             </div>
           </div>
+        </div>
         </div>
           </div>
         </div>

--- a/ducky_app/frontend/ui_web/web/src/components/ModelSelector.tsx
+++ b/ducky_app/frontend/ui_web/web/src/components/ModelSelector.tsx
@@ -75,6 +75,8 @@ interface ModelSelectorProps {
   menuPlacement?: "top" | "bottom";
   /** Trigger text when nothing is selected. */
   placeholder?: string;
+  /** Bump to open the dropdown from outside (the composer's `/model` command). */
+  openSignal?: number;
 }
 
 export function ModelSelector({
@@ -90,6 +92,7 @@ export function ModelSelector({
   preserveSelection = false,
   menuPlacement = "top",
   placeholder = "Pick a model",
+  openSignal = 0,
 }: ModelSelectorProps) {
   const contrib = usePluginContributions();
   const [isOpen, setIsOpen] = useState(false);
@@ -408,6 +411,15 @@ export function ModelSelector({
     pushHist();
     void loadAgents();
   };
+
+  const openDropdownRef = useRef(openDropdown);
+  openDropdownRef.current = openDropdown;
+  const lastOpenSignal = useRef(openSignal);
+  useEffect(() => {
+    if (openSignal === lastOpenSignal.current) return;
+    lastOpenSignal.current = openSignal;
+    openDropdownRef.current();
+  }, [openSignal]);
 
   useEffect(() => {
     const onPop = () => {

--- a/ducky_app/frontend/ui_web/web/src/components/SlashCommandMenu.tsx
+++ b/ducky_app/frontend/ui_web/web/src/components/SlashCommandMenu.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from "react";
+
+import type { SlashCommand } from "./slashCommands";
+
+interface SlashCommandMenuProps {
+  commands: SlashCommand[];
+  activeIndex: number;
+  onHover: (index: number) => void;
+  onSelect: (command: SlashCommand) => void;
+}
+
+/** Command palette above the composer, driven by the `/` prefix in the textarea. */
+export function SlashCommandMenu({
+  commands,
+  activeIndex,
+  onHover,
+  onSelect,
+}: SlashCommandMenuProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const active = listRef.current?.children[activeIndex];
+    active?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+
+  if (commands.length === 0) return null;
+
+  return (
+    <div className="slash-command-menu no-drag">
+      <div className="slash-command-menu-header">Commands</div>
+      <div ref={listRef} className="slash-command-menu-list">
+        {commands.map((cmd, i) => (
+          <button
+            key={cmd.name}
+            type="button"
+            className={`slash-command-option${i === activeIndex ? " is-active" : ""}`}
+            onMouseMove={() => onHover(i)}
+            // Keep the textarea focused — blur would close the menu before the click lands.
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => onSelect(cmd)}
+          >
+            <span className="slash-command-option-name">
+              /{cmd.name}
+              {cmd.args ? <span className="slash-command-option-args"> {cmd.args}</span> : null}
+            </span>
+            <span className="slash-command-option-desc">{cmd.description}</span>
+          </button>
+        ))}
+      </div>
+      <div className="slash-command-menu-footer">
+        <kbd>↑</kbd>
+        <kbd>↓</kbd>
+        <span>navigate</span>
+        <kbd>Tab</kbd>
+        <span>complete</span>
+        <kbd>Esc</kbd>
+        <span>dismiss</span>
+      </div>
+    </div>
+  );
+}

--- a/ducky_app/frontend/ui_web/web/src/components/SnipButton.tsx
+++ b/ducky_app/frontend/ui_web/web/src/components/SnipButton.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Icons } from "../icons/Icons";
 import { getApi } from "../hooks/usePanelApi";
+import { captureSnipFile } from "./snipCapture";
 
 interface SnipButtonProps {
   disabled?: boolean;
@@ -14,20 +15,11 @@ export function SnipButton({ disabled, onCaptured }: SnipButtonProps) {
   if (!getApi()?.snip_screen) return null;
 
   const handleClick = async () => {
-    const api = getApi();
-    if (!api?.snip_screen || busy) return;
+    if (busy) return;
     setBusy(true);
     try {
-      const res = await api.snip_screen();
-      if (res?.ok && res.data_base64) {
-        const bin = atob(res.data_base64);
-        const bytes = new Uint8Array(bin.length);
-        for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-        const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
-        const name = res.name || `snip-${stamp}.png`;
-        const projectPath = (res.path || "").trim() || undefined;
-        onCaptured(new File([bytes], name, { type: "image/png" }), { projectPath });
-      }
+      const snip = await captureSnipFile();
+      if (snip) onCaptured(snip.file, { projectPath: snip.projectPath });
     } finally {
       setBusy(false);
     }

--- a/ducky_app/frontend/ui_web/web/src/components/slashCommands.test.ts
+++ b/ducky_app/frontend/ui_web/web/src/components/slashCommands.test.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  composerPlaceholder,
+  filterCommands,
+  matchSlashCommand,
+  readSlashQuery,
+  type SlashCommand,
+} from "./slashCommands";
+
+const noop = () => {};
+
+const commands: SlashCommand[] = [
+  { name: "agent", description: "", keywords: ["mode"], run: noop },
+  { name: "ask", description: "", keywords: ["mode"], run: noop },
+  { name: "goal", description: "", keywords: ["objective"], requiresArgument: true, run: noop },
+  { name: "help", description: "", run: noop },
+];
+
+describe("readSlashQuery", () => {
+  it("opens on a bare slash and reports an empty query", () => {
+    expect(readSlashQuery("/")).toBe("");
+  });
+
+  it("reports the command name being typed", () => {
+    expect(readSlashQuery("/go")).toBe("go");
+  });
+
+  it("stays closed when the slash is not the first character", () => {
+    expect(readSlashQuery("fix Content/Verse/main.verse")).toBeNull();
+    expect(readSlashQuery(" /goal")).toBeNull();
+  });
+
+  it("closes once the user moves on to the argument", () => {
+    expect(readSlashQuery("/goal ")).toBeNull();
+    expect(readSlashQuery("/goal ship the lobby")).toBeNull();
+  });
+});
+
+describe("filterCommands", () => {
+  it("returns everything for an empty query", () => {
+    expect(filterCommands(commands, "")).toHaveLength(commands.length);
+  });
+
+  it("matches on a name prefix", () => {
+    expect(filterCommands(commands, "a").map((c) => c.name)).toEqual(["agent", "ask"]);
+  });
+
+  it("matches on keywords but ranks name hits first", () => {
+    expect(filterCommands(commands, "o").map((c) => c.name)).toEqual(["goal"]);
+    expect(filterCommands(commands, "as").map((c) => c.name)).toEqual(["ask"]);
+  });
+
+  it("returns nothing for an unknown prefix", () => {
+    expect(filterCommands(commands, "zz")).toEqual([]);
+  });
+});
+
+describe("matchSlashCommand", () => {
+  it("matches a bare command", () => {
+    expect(matchSlashCommand("/help", commands)).toMatchObject({
+      command: { name: "help" },
+      argument: "",
+    });
+  });
+
+  it("splits the argument off the command name", () => {
+    expect(matchSlashCommand("/goal ship the lobby", commands)).toMatchObject({
+      command: { name: "goal" },
+      argument: "ship the lobby",
+    });
+  });
+
+  it("is case insensitive on the name", () => {
+    expect(matchSlashCommand("/HELP", commands)?.command.name).toBe("help");
+  });
+
+  it("ignores unknown commands so they still reach the ducky", () => {
+    expect(matchSlashCommand("/nope", commands)).toBeNull();
+  });
+
+  it("ignores plain messages and paths", () => {
+    expect(matchSlashCommand("hello", commands)).toBeNull();
+    expect(matchSlashCommand("look at /goal in the docs", commands)).toBeNull();
+  });
+});
+
+describe("composerPlaceholder", () => {
+  const idle = {
+    liveVoiceMuted: false,
+    isGroup: false,
+    groupEmpty: false,
+    agentRunning: false,
+    noModelsAvailable: false,
+    modelLabel: "Ducky",
+  };
+
+  it("tells the idle ask composer that / opens commands", () => {
+    expect(composerPlaceholder(idle)).toContain("/ for commands");
+    expect(composerPlaceholder(idle)).toContain("Ask Ducky");
+  });
+
+  it("does not tack the hint onto muted, no-models, or follow-up copy", () => {
+    expect(composerPlaceholder({ ...idle, liveVoiceMuted: true })).not.toContain("/ for commands");
+    expect(composerPlaceholder({ ...idle, noModelsAvailable: true })).not.toContain("/ for commands");
+    expect(composerPlaceholder({ ...idle, agentRunning: true })).not.toContain("/ for commands");
+  });
+});
+
+describe("slash menu host", () => {
+  it("renders the palette outside the container-query input box", () => {
+    const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "ChatPane.tsx"), "utf8");
+    const menu = src.indexOf("<SlashCommandMenu");
+    const box = src.indexOf("chat-pane-input-box");
+    expect(menu).toBeGreaterThan(-1);
+    expect(box).toBeGreaterThan(-1);
+    expect(menu).toBeLessThan(box);
+  });
+});

--- a/ducky_app/frontend/ui_web/web/src/components/slashCommands.ts
+++ b/ducky_app/frontend/ui_web/web/src/components/slashCommands.ts
@@ -1,0 +1,186 @@
+import { getApi } from "../hooks/usePanelApi";
+import type { AgentMode } from "../types/panel";
+
+/** What the composer knows about itself — decides which commands are offered. */
+export interface SlashCommandScope {
+  codingAgent: string;
+  isGroup: boolean;
+}
+
+export interface SlashCommandContext {
+  chatId: string;
+  /** Everything typed after the command name, trimmed. */
+  argument: string;
+  setAgentMode: (mode: AgentMode) => void;
+  openModelPicker: () => void;
+  captureSnip: () => void;
+  showHelp: () => void;
+  /** Transient status line under the composer. */
+  report: (message: string) => void;
+}
+
+export interface SlashCommand {
+  /** Command name without the leading slash. */
+  name: string;
+  /** Argument hint shown next to the name, e.g. "<goal>". */
+  args?: string;
+  description: string;
+  /** Extra terms the filter matches on, so "/objective" still finds /goal. */
+  keywords?: string[];
+  /** Refuse to run with an empty argument, and keep the menu hint visible. */
+  requiresArgument?: boolean;
+  /** Omitted means the command is offered for every agent and chat kind. */
+  isAvailable?: (scope: SlashCommandScope) => boolean;
+  run: (ctx: SlashCommandContext) => void | Promise<void>;
+}
+
+/** Modes and the model picker live in the solo-chat toolbar only. */
+const soloChatOnly = (scope: SlashCommandScope) => !scope.isGroup;
+
+function modeCommand(mode: AgentMode, description: string): SlashCommand {
+  return {
+    name: mode,
+    description,
+    keywords: ["mode"],
+    isAvailable: soloChatOnly,
+    run: ({ setAgentMode, report }) => {
+      setAgentMode(mode);
+      report(`Mode set to ${mode}.`);
+    },
+  };
+}
+
+async function createTask(
+  ctx: SlashCommandContext,
+  title: string,
+  goal: string,
+): Promise<void> {
+  const api = getApi();
+  if (!api?.create_task) {
+    ctx.report("Tasks are unavailable — the panel API did not expose create_task.");
+    return;
+  }
+  try {
+    const task = await api.create_task(title, goal, [ctx.chatId]);
+    const created = String(task?.title || title);
+    ctx.report(`Task created: ${created}`);
+  } catch (err) {
+    ctx.report(`Could not create the task: ${String(err)}`);
+  }
+}
+
+/** First sentence or first 60 characters — a task title, not a paragraph. */
+function titleFromGoal(goal: string): string {
+  const firstLine = goal.split("\n")[0].trim();
+  if (firstLine.length <= 60) return firstLine;
+  return `${firstLine.slice(0, 57).trimEnd()}…`;
+}
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+  modeCommand("agent", "Let the ducky edit files and run tools."),
+  modeCommand("plan", "Have the ducky draft a plan before touching code."),
+  modeCommand("ask", "Read-only answers — no edits, no tools."),
+  {
+    name: "goal",
+    args: "<goal>",
+    description: "Track an objective for this chat as a task.",
+    keywords: ["objective", "task"],
+    requiresArgument: true,
+    run: (ctx) => createTask(ctx, titleFromGoal(ctx.argument), ctx.argument),
+  },
+  {
+    name: "task",
+    args: "<title>",
+    description: "Create a task linked to this chat.",
+    keywords: ["todo"],
+    requiresArgument: true,
+    run: (ctx) => createTask(ctx, ctx.argument, ""),
+  },
+  {
+    name: "model",
+    description: "Pick the model this chat runs on.",
+    keywords: ["llm", "agent"],
+    isAvailable: soloChatOnly,
+    run: ({ openModelPicker }) => openModelPicker(),
+  },
+  {
+    name: "snip",
+    description: "Capture a region of the screen into the composer.",
+    keywords: ["screenshot", "capture"],
+    isAvailable: () => Boolean(getApi()?.snip_screen),
+    run: ({ captureSnip }) => captureSnip(),
+  },
+  {
+    name: "help",
+    description: "List every command available here.",
+    keywords: ["commands"],
+    run: ({ showHelp }) => showHelp(),
+  },
+];
+
+export function commandsForScope(scope: SlashCommandScope): SlashCommand[] {
+  return SLASH_COMMANDS.filter((cmd) => cmd.isAvailable?.(scope) ?? true);
+}
+
+export interface ComposerPlaceholderInput {
+  liveVoiceMuted: boolean;
+  isGroup: boolean;
+  groupEmpty: boolean;
+  agentRunning: boolean;
+  noModelsAvailable: boolean;
+  modelLabel: string;
+}
+
+/** Idle composers mention `/` so the command palette is discoverable. */
+export function composerPlaceholder(p: ComposerPlaceholderInput): string {
+  if (p.liveVoiceMuted) return "You're muted — type to chat (Shift+Enter for newline)";
+  if (p.isGroup) {
+    if (p.groupEmpty) return "Invite a ducky above to start the roundtable…";
+    if (p.agentRunning) return "Add a follow-up… (Shift+Enter for newline)";
+    return "Message the group… (Shift+Enter for newline)  ·  / for commands";
+  }
+  if (p.noModelsAvailable) {
+    return "No models available — use the button below to open Settings → LLMs";
+  }
+  if (p.agentRunning) return "Add a follow-up… (Shift+Enter for newline)";
+  return `Ask ${p.modelLabel}... (Shift+Enter for newline)  ·  / for commands`;
+}
+
+/**
+ * The command name being typed, or null when the composer is not in that state.
+ * Only a leading slash counts, and only until the first space — once the user
+ * starts on the argument the menu gets out of the way.
+ */
+export function readSlashQuery(text: string): string | null {
+  const match = /^\/([a-z0-9_-]*)$/i.exec(text);
+  return match ? match[1] : null;
+}
+
+export function filterCommands(commands: SlashCommand[], query: string): SlashCommand[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return commands;
+  const matches = commands.filter(
+    (cmd) =>
+      cmd.name.startsWith(q) ||
+      cmd.keywords?.some((kw) => kw.toLowerCase().startsWith(q)),
+  );
+  // Prefix hits on the name itself rank above keyword-only hits.
+  return matches.sort((a, b) => {
+    const an = a.name.startsWith(q) ? 0 : 1;
+    const bn = b.name.startsWith(q) ? 0 : 1;
+    return an - bn || a.name.localeCompare(b.name);
+  });
+}
+
+/** A fully typed command line, ready to run instead of being sent to the ducky. */
+export function matchSlashCommand(
+  text: string,
+  commands: SlashCommand[],
+): { command: SlashCommand; argument: string } | null {
+  const match = /^\/([a-z0-9_-]+)(?:[ \t]+([\s\S]*))?$/i.exec(text.trim());
+  if (!match) return null;
+  const name = match[1].toLowerCase();
+  const command = commands.find((cmd) => cmd.name === name);
+  if (!command) return null;
+  return { command, argument: (match[2] ?? "").trim() };
+}

--- a/ducky_app/frontend/ui_web/web/src/components/snipCapture.ts
+++ b/ducky_app/frontend/ui_web/web/src/components/snipCapture.ts
@@ -1,0 +1,23 @@
+import { getApi } from "../hooks/usePanelApi";
+
+export interface SnipResult {
+  file: File;
+  projectPath?: string;
+}
+
+/** Runs the Windows region snipper and turns the reply into a PNG File. */
+export async function captureSnipFile(): Promise<SnipResult | null> {
+  const api = getApi();
+  if (!api?.snip_screen) return null;
+  const res = await api.snip_screen();
+  if (!res?.ok || !res.data_base64) return null;
+  const bin = atob(res.data_base64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  const name = res.name || `snip-${stamp}.png`;
+  return {
+    file: new File([bytes], name, { type: "image/png" }),
+    projectPath: (res.path || "").trim() || undefined,
+  };
+}

--- a/ducky_app/frontend/ui_web/web/src/theme/styles/chat.css
+++ b/ducky_app/frontend/ui_web/web/src/theme/styles/chat.css
@@ -169,6 +169,14 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
+  position: relative;
+  z-index: 12;
+}
+
+/* Hosts the slash palette so container queries on the input box cannot clip it. */
+.chat-pane-composer-host {
+  position: relative;
+  z-index: 12;
 }
 
 /* Active plan stays above the composer — not inside the scrolling transcript. */
@@ -340,6 +348,114 @@
   backdrop-filter: var(--blur-md);
   container-type: inline-size;
   container-name: chat-composer;
+}
+
+/* ── Slash command palette (opens upward, over the message list) ── */
+.slash-command-menu {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 0;
+  right: 0;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  background: var(--dropdown-bg);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-dropdown);
+  overflow: hidden;
+  animation: scaleIn 0.12s ease-out forwards;
+  transform-origin: bottom center;
+}
+
+.slash-command-menu-header {
+  padding: 8px 12px 4px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.slash-command-menu-list {
+  display: flex;
+  flex-direction: column;
+  max-height: min(320px, 40vh);
+  overflow-y: auto;
+  padding: 0 6px 6px;
+}
+
+.slash-command-option {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--fg);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.slash-command-option.is-active {
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+}
+
+.slash-command-option-name {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-weight: 600;
+}
+
+.slash-command-option-args {
+  font-weight: 400;
+  color: var(--muted);
+}
+
+.slash-command-option-desc {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.slash-command-menu-footer {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 12px;
+  border-top: 1px solid var(--border-light);
+  font-size: 10px;
+  color: var(--muted);
+}
+
+.slash-command-menu-footer kbd {
+  padding: 1px 5px;
+  border: 1px solid var(--border-light);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.slash-command-menu-footer span + kbd {
+  margin-left: 5px;
+}
+
+.slash-command-status {
+  margin: 8px 20px 0;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--text) 6%, transparent);
+  font-size: 12px;
+  color: var(--fg-dim);
 }
 
 .chat-pane-input-resize-handle {


### PR DESCRIPTION
## Summary
- Typing `/` in the composer lists available commands (`/goal`, `/task`, `/plan`, `/help`, …).
- Menu sits outside the container-query input box so it is no longer clipped.

## Test plan
- [ ] Type `/` in a chat — menu appears above the composer
- [ ] `/go` filters to `/goal`; Tab completes; Esc dismisses
- [ ] `/goal ship the lobby` creates a task

Made with [Cursor](https://cursor.com)