### PR TITLE
Run Scene Graph helper tests without UEFN

### DIFF
--- a/tests/test_scene_graph_filters.py
+++ b/tests/test_scene_graph_filters.py
@@ -7,7 +7,14 @@ from pathlib import Path
 
 import pytest
 
-_FILTERS = Path(__file__).resolve().parents[1] / "uefn_listener" / "listener" / "registry" / "scene_graph_filters.py"
+_FILTERS = (
+    Path(__file__).resolve().parents[1]
+    / "ducky_app"
+    / "uefn_listener"
+    / "listener"
+    / "registry"
+    / "scene_graph_filters.py"
+)
 _spec = importlib.util.spec_from_file_location("scene_graph_filters", _FILTERS)
 assert _spec and _spec.loader
 _mod = importlib.util.module_from_spec(_spec)


### PR DESCRIPTION
## Summary
- move the pure Scene Graph helper test out of the `listener.registry` package
- load the helper module directly from its real repository path

Pytest imports package `__init__.py` files during collection. Keeping this test under `listener.registry` therefore loaded UEFN command modules and failed immediately when the `unreal` module was unavailable, despite the test itself being intentionally editor-independent.

## Verification
- `3 passed` for `tests/test_scene_graph_filters.py`
- `659 tests collected` with no collection errors
- Ruff passes for the moved test