### PR TITLE
Fix viewport capture so screenshots produce a PNG

### DIFF
--- a/ducky_app/backend/tools/uefn/editor.py
+++ b/ducky_app/backend/tools/uefn/editor.py
@@ -22,7 +22,17 @@ def _wait_for_screenshot_file(result: dict[str, Any]) -> dict[str, Any]:
         return result
     path = str(result.get("path") or "").strip()
     if not path:
-        return result
+        # No path at all means the capture never produced a file. Saying
+        # "kicked off, wait a frame" here is how a dead capture looked like a
+        # pending one — with nothing on its way.
+        return {
+            **result,
+            "error": (
+                "Screenshot failed: the listener returned no path, so no PNG was written. "
+                "Reload the listener and retry; if it persists, viewport capture is "
+                "unavailable in this UEFN build."
+            ),
+        }
     src = Path(path)
     if src.is_file() and src.stat().st_size > 0:
         out = {**result}

--- a/ducky_app/backend/tools/uefn/test_agent_hardening.py
+++ b/ducky_app/backend/tools/uefn/test_agent_hardening.py
@@ -454,6 +454,15 @@ def test_wait_for_screenshot_file_errors_when_missing(tmp_path, monkeypatch):
     assert "not ready" in out["error"]
 
 
+def test_wait_for_screenshot_file_errors_when_listener_returned_no_path():
+    """A capture that "started" with no path is a failure, not a pending PNG."""
+    from backend.tools.uefn import editor as editor_mod
+
+    out = editor_mod._wait_for_screenshot_file({"await_path": True, "method": "Shot"})
+    assert "error" in out
+    assert "no path" in out["error"].lower()
+
+
 def test_vision_attachments_from_capture_result(tmp_path):
     from backend.agent.capture_vision import vision_attachments_from_capture_result
 

--- a/ducky_app/uefn_listener/listener/registry/editor_control.py
+++ b/ducky_app/uefn_listener/listener/registry/editor_control.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import base64
+import json
 import os
+import tempfile
 import time
 import uuid
 from typing import Any
@@ -17,97 +20,53 @@ def _editor_world():
     return unreal.EditorLevelLibrary.get_editor_world()
 
 
-def _screenshots_dir() -> str:
+#: Epic's in-process toolset API. ``CaptureViewport`` reads back the level
+#: viewport and hands us the PNG directly — no file hunt, no console command,
+#: and it completes on the calling frame.
+_CAPTURE_TOOLSET = "EditorToolset.EditorAppToolset"
+_CAPTURE_TOOL = "CaptureViewport"
+
+
+def _captures_dir() -> str:
+    """OS temp — never the UEFN project folder. The host copies into AppData."""
+    root = os.path.join(tempfile.gettempdir(), "ducky_captures")
+    os.makedirs(root, exist_ok=True)
+    return root
+
+
+def _capture_viewport_png() -> bytes:
+    """PNG bytes of the active level viewport, or raise with why it failed."""
+    registry = getattr(unreal, "ToolsetRegistry", None)
+    if registry is None or not registry.is_available():
+        raise RuntimeError(
+            "Viewport capture unavailable: Epic's ToolsetRegistry is not registered "
+            "in this UEFN build (EditorToolset plugin missing or not loaded yet)"
+        )
+    result = registry.execute_tool(_CAPTURE_TOOLSET, _CAPTURE_TOOL, "{}")
+    # The capture completes on the calling frame. If it ever does not, say so —
+    # waiting here would block the tick that has to finish it.
+    if not result.is_complete:
+        raise RuntimeError("Viewport capture did not complete on this frame")
+    error = str(getattr(result, "error", "") or "")
+    if error:
+        raise RuntimeError(f"Viewport capture failed: {error}")
     try:
-        project_dir = unreal.Paths.project_saved_dir()
-    except Exception:
-        project_dir = ""
-    if not project_dir:
-        return ""
-    return os.path.join(project_dir, "Screenshots")
+        payload = json.loads(str(result.value or "{}"))
+    except (TypeError, ValueError) as e:
+        raise RuntimeError(f"Viewport capture returned unreadable JSON: {e}") from e
+    image = ((payload.get("returnValue") or {}).get("image") or {})
+    data = str(image.get("data") or "")
+    if not data:
+        raise RuntimeError("Viewport capture returned an empty image")
+    return base64.b64decode(data)
 
 
-def _expected_screenshot_path(filename: str) -> str:
-    name = os.path.basename(filename or "")
-    if not name:
-        return ""
-    root = _screenshots_dir()
-    return os.path.join(root, name) if root else name
-
-
-def _resolve_screenshot_path(filename: str, *, since: float = 0.0) -> str:
-    """Locate a fresh PNG under Saved/Screenshots only (never walk all of Saved)."""
-    name = os.path.basename(filename or "")
-    if not name:
-        return ""
-    if os.path.isabs(filename) and os.path.isfile(filename):
-        try:
-            if since <= 0.0 or os.path.getmtime(filename) >= since - 1.0:
-                return filename
-        except OSError:
-            return filename
-    root = _screenshots_dir()
-    if not root or not os.path.isdir(root):
-        return ""
-    # Non-recursive first (UE writes here directly).
-    direct = os.path.join(root, name)
-    if os.path.isfile(direct):
-        try:
-            if since <= 0.0 or os.path.getmtime(direct) >= since - 1.0:
-                return direct
-        except OSError:
-            return direct
-    # One level of subdirs only (Windows/UE sometimes nests by map name).
-    try:
-        for entry in os.listdir(root):
-            sub = os.path.join(root, entry)
-            if not os.path.isdir(sub):
-                continue
-            path = os.path.join(sub, name)
-            if not os.path.isfile(path):
-                continue
-            try:
-                if since <= 0.0 or os.path.getmtime(path) >= since - 1.0:
-                    return path
-            except OSError:
-                return path
-    except OSError:
-        pass
-    return ""
-
-
-def _newest_screenshot_since(since: float) -> str:
-    """Newest .png under Screenshots modified at/after ``since`` (shallow)."""
-    root = _screenshots_dir()
-    if not root or not os.path.isdir(root):
-        return ""
-    newest = ""
-    newest_mtime = 0.0
-    cutoff = since - 1.0
-    candidates: list[str] = []
-    try:
-        for entry in os.listdir(root):
-            path = os.path.join(root, entry)
-            if os.path.isfile(path) and entry.lower().endswith(".png"):
-                candidates.append(path)
-            elif os.path.isdir(path):
-                try:
-                    for child in os.listdir(path):
-                        if child.lower().endswith(".png"):
-                            candidates.append(os.path.join(path, child))
-                except OSError:
-                    continue
-    except OSError:
-        return ""
-    for path in candidates:
-        try:
-            mtime = os.path.getmtime(path)
-        except OSError:
-            continue
-        if mtime >= cutoff and mtime >= newest_mtime:
-            newest = path
-            newest_mtime = mtime
-    return newest
+def _capture_filename(filename: str) -> str:
+    """Unique PNG name, seeded from the caller's name when it gave one."""
+    raw = os.path.basename((filename or "").strip())
+    stem = raw[:-4] if raw.lower().endswith(".png") and raw.lower() != ".png" else ""
+    safe = "".join(ch if ch.isalnum() or ch in "-_" else "_" for ch in stem)[:48] or "uefn_ducky"
+    return f"{safe}_{int(time.time())}_{uuid.uuid4().hex[:8]}.png"
 
 
 def exec_console_command(command: str) -> dict:
@@ -130,62 +89,32 @@ def save_all_dirty(content: bool = True, maps: bool = True) -> dict:
 def take_high_res_screenshot(width: int = 1280, height: int = 720, filename: str = "") -> dict:
     """Capture the active viewport without freezing the editor.
 
-    **Never** uses ``AutomationLibrary.take_high_res_screenshot`` / HighResShot —
-    those do a synchronous offscreen render on the Slate tick and can freeze UEFN
-    for tens of seconds on dense levels (then the host hits its 30s bridge timeout).
+    **Never** uses ``AutomationLibrary`` / ``HighResShot`` — those do a
+    synchronous offscreen render on the Slate tick and can freeze UEFN for tens
+    of seconds on dense levels. **Never** uses the ``Shot`` console command
+    either: that one is a *game* viewport command and writes nothing at all in
+    the editor, which is how captures used to "start" and never produce a PNG.
 
-    Captures the current viewport buffer via ``take_screenshot`` (or console
-    ``Shot``). ``width``/``height`` are recorded as requested size only — the PNG
-    matches the viewport. Does not sleep on the game thread; the host waits for
-    the file if the write lands on the next frame.
+    Goes through Epic's ``EditorAppToolset.CaptureViewport``, which reads the
+    viewport back on the calling frame and returns the PNG inline. The file is
+    written to OS temp and the host copies it into AppData ``tool_captures``.
+    ``width``/``height`` are recorded as the requested size only — the PNG
+    matches the viewport.
     """
-    req_w, req_h = int(width), int(height)
-    # Unique name so resolve never picks a stale prior capture.
-    raw = os.path.basename((filename or "").strip())
-    if raw.lower().endswith(".png") and raw.lower() != ".png":
-        stem = raw[:-4]
-        safe = "".join(ch if ch.isalnum() or ch in "-_" else "_" for ch in stem)[:48] or "uefn_ducky"
-    else:
-        safe = "uefn_ducky"
-    fn = f"{safe}_{int(time.time())}_{uuid.uuid4().hex[:8]}.png"
-    started = time.time()
-    method = ""
-    try:
-        take_fn = getattr(unreal.AutomationLibrary, "take_screenshot", None)
-        if callable(take_fn):
-            take_fn(fn)
-            method = "take_screenshot"
-        else:
-            world = _editor_world()
-            unreal.SystemLibrary.execute_console_command(world, "Shot")
-            method = "Shot"
-            fn = ""
-    except Exception as e:
-        raise RuntimeError(f"Screenshot failed: {e}") from e
-
-    # Do NOT time.sleep here — sleeping on the Slate tick freezes the entire editor
-    # and can prevent the async PNG write from finishing.
-    path = ""
-    if fn:
-        path = _resolve_screenshot_path(fn, since=started)
-    if not path:
-        path = _newest_screenshot_since(started)
-    expected = path or (_expected_screenshot_path(fn) if fn else "")
+    raw = _capture_viewport_png()
+    name = _capture_filename(filename)
+    path = os.path.join(_captures_dir(), name)
+    with open(path, "wb") as handle:
+        handle.write(raw)
     out: dict[str, Any] = {
-        "width": req_w,
-        "height": req_h,
-        "filename": os.path.basename(expected or fn or "screenshot.png"),
-        "method": method,
+        "width": int(width),
+        "height": int(height),
+        "filename": name,
+        "path": path,
+        "bytes": len(raw),
+        "method": _CAPTURE_TOOL,
         "viewport_capture": True,
     }
-    if expected:
-        out["path"] = expected
-    if not path:
-        out["await_path"] = True
-        out["hint"] = (
-            "Viewport capture kicked off — PNG may appear on the next editor frame. "
-            "Host waits briefly for path; do not Bash-find."
-        )
     return out
 
 

--- a/ducky_app/uefn_listener/listener/test_editor_control_screenshot.py
+++ b/ducky_app/uefn_listener/listener/test_editor_control_screenshot.py
@@ -1,0 +1,157 @@
+"""Viewport capture must produce a PNG — no Unreal required.
+
+Regression for the capture that "started" and never produced a file: the
+listener asked for ``unreal.AutomationLibrary.take_screenshot`` (a name UEFN
+does not have), fell through to the ``Shot`` console command (a game-viewport
+command that writes nothing in the editor), and returned no path at all.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+MODULE = Path(__file__).resolve().parent / "registry" / "editor_control.py"
+
+# Smallest valid PNG (1x1). Stands in for the base64 CaptureViewport returns.
+PNG_BYTES = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+
+class FakeRegistry:
+    """Stand-in for ``unreal.ToolsetRegistry`` (Epic's in-process toolset API)."""
+
+    def __init__(self, *, available: bool = True, image_b64: str | None = None, error: str = ""):
+        self._available = available
+        self._image_b64 = image_b64
+        self._error = error
+        self.calls: list[tuple[str, str, str]] = []
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def execute_tool(self, toolset: str, tool: str, json_input: str) -> Any:
+        self.calls.append((toolset, tool, json_input))
+        payload: dict[str, Any] = {"returnValue": {}}
+        if self._image_b64 is not None:
+            payload["returnValue"]["image"] = {"mimeType": "image/png", "data": self._image_b64}
+        outer = self
+
+        class _Result:
+            is_complete = True
+            error = outer._error
+            value = json.dumps(payload)
+
+        return _Result()
+
+
+class FakeAutomationLibrary:
+    """UEFN's real AutomationLibrary: no ``take_screenshot`` attribute."""
+
+    @staticmethod
+    def take_automation_screenshot(*args, **kwargs):  # pragma: no cover - must not be called
+        raise AssertionError("automation screenshot path must not be used")
+
+
+def _load(monkeypatch, tmp_path, *, registry: FakeRegistry | None) -> tuple[Any, list[str]]:
+    console: list[str] = []
+    unreal = types.ModuleType("unreal")
+
+    class Paths:
+        @staticmethod
+        def project_saved_dir() -> str:
+            return str(tmp_path / "project" / "Saved")
+
+        @staticmethod
+        def project_dir() -> str:
+            return str(tmp_path / "project")
+
+    class SystemLibrary:
+        @staticmethod
+        def execute_console_command(world, command):
+            console.append(command)
+
+    class EditorLevelLibrary:
+        @staticmethod
+        def get_editor_world():
+            return object()
+
+    unreal.Paths = Paths
+    unreal.SystemLibrary = SystemLibrary
+    unreal.EditorLevelLibrary = EditorLevelLibrary
+    unreal.AutomationLibrary = FakeAutomationLibrary
+    if registry is not None:
+        unreal.ToolsetRegistry = registry
+
+    dispatch = types.ModuleType("listener.dispatch")
+    dispatch.register = lambda name: (lambda fn: fn)
+    serialize = types.ModuleType("listener.serialize")
+    serialize.serialize = lambda value: value
+    package = types.ModuleType("listener")
+    package.__path__ = [str(MODULE.parent.parent)]
+
+    monkeypatch.setitem(sys.modules, "unreal", unreal)
+    monkeypatch.setitem(sys.modules, "listener", package)
+    monkeypatch.setitem(sys.modules, "listener.dispatch", dispatch)
+    monkeypatch.setitem(sys.modules, "listener.serialize", serialize)
+
+    spec = importlib.util.spec_from_file_location("editor_control_under_test", MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module, console
+
+
+def test_viewport_capture_writes_a_png_and_returns_its_path(monkeypatch, tmp_path):
+    registry = FakeRegistry(image_b64=base64.b64encode(PNG_BYTES).decode("ascii"))
+    module, console = _load(monkeypatch, tmp_path, registry=registry)
+
+    out = module.take_high_res_screenshot(width=1280, height=720, filename="corner.png")
+
+    path = Path(str(out.get("path") or ""))
+    assert path.is_file(), f"no PNG on disk: {out}"
+    assert path.read_bytes() == PNG_BYTES
+    assert not out.get("error")
+    assert not out.get("await_path"), "a written file must not be reported as pending"
+
+
+def test_viewport_capture_never_falls_back_to_the_shot_console_command(monkeypatch, tmp_path):
+    registry = FakeRegistry(image_b64=base64.b64encode(PNG_BYTES).decode("ascii"))
+    module, console = _load(monkeypatch, tmp_path, registry=registry)
+
+    module.take_high_res_screenshot()
+
+    assert console == [], f"'Shot' writes nothing in the UEFN editor: {console}"
+    assert registry.calls, "capture must go through the toolset registry"
+    toolset, tool, _ = registry.calls[0]
+    assert tool == "CaptureViewport"
+    assert "EditorAppToolset" in toolset
+
+
+def test_capture_never_writes_into_the_uefn_project_folder(monkeypatch, tmp_path):
+    registry = FakeRegistry(image_b64=base64.b64encode(PNG_BYTES).decode("ascii"))
+    module, _ = _load(monkeypatch, tmp_path, registry=registry)
+
+    out = module.take_high_res_screenshot()
+
+    project = (tmp_path / "project").resolve()
+    written = Path(str(out["path"])).resolve()
+    assert project not in written.parents
+
+
+def test_missing_registry_reports_an_error_instead_of_a_silent_no_op(monkeypatch, tmp_path):
+    module, console = _load(monkeypatch, tmp_path, registry=None)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        module.take_high_res_screenshot()
+
+    assert "capture" in str(excinfo.value).lower()
+    assert console == []


### PR DESCRIPTION

## Summary
- `take_high_res_screenshot` asked for `unreal.AutomationLibrary.take_screenshot`, a name UEFN does not have. `getattr` returned `None` on every call, so the capture always fell through to the console fallback.
- That fallback ran the `Shot` console command, which is a *game* viewport command and writes nothing in the editor. The editor log shows eight `Shot` commands with zero screenshot writes, and no `Saved/Screenshots` directory has ever existed.
- The fallback also cleared the filename, so the listener returned no path at all — and the host treated a missing path as "capture kicked off, PNG lands next frame". A dead capture was reported as a pending one, which is why screenshots started and no PNG ever appeared.
- Capture now goes through Epic's `EditorAppToolset.CaptureViewport` via `unreal.ToolsetRegistry`, which reads the viewport back on the calling frame and returns the PNG inline. The file is written to OS temp and the host copies it into AppData `tool_captures` as before.
- A result with no path is now an explicit error on the host instead of a silent "still on its way".
- Drops the `Saved/Screenshots` file hunt (~120 lines) that only existed to chase a PNG the console fallback never wrote.

## Verification
- 4 new listener tests in `test_editor_control_screenshot.py`, written before the fix: all four failed against the old code, all four pass now (a PNG is written, no `Shot` fallback, nothing written into the UEFN project folder, explicit error when the registry is unavailable)
- 1 new host test covering the missing-path silent success
- `144 passed` across `backend/tools/uefn/` and `uefn_listener/listener/`
- End to end against a live UEFN editor: valid 1121x858 PNG, 1.07 MB, in 0.127s — where the old path produced nothing in 8s



